### PR TITLE
feat: Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,40 @@
+name: Bug Report
+description:  Report an issue to help improve the project.
+title: "[BUG] <description>"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this bug?
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Docs
+      description: Make sure you went through the README file and docs
+      options:
+        - label: "I have went through the project's README file"
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest features, propose improvements, discuss new ideas.
+title: "[FEATURE] <description>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Detailed description
+      description: Provide a detailed description of the change or addition you are proposing
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: |
+        Why is this change important to you? How would you use it?
+        How can it benefit other users?
+    validations:
+      required: true
+  - type: textarea
+    id: possibleimpl
+    attributes:
+      label: Possible implementation
+      description: Not obligatory, but suggest an idea for implementing addition or change
+    validations:
+      required: false
+  - type: textarea
+    id: extrainformation
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this feature?
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Docs
+      description: Make sure you went through the README file and docs
+      options:
+        - label: "I have went through the project's README file"
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Fixes Issue
+
+
+## Changes proposed
+
+
+## Screenshots
+
+
+## Note to reviewers
+


### PR DESCRIPTION
### Changes

Added Github issues and pull request templates.

### screenshot(sample):
You can check it out in my [repo](https://github.com/lem0n4id/test)

![image](https://user-images.githubusercontent.com/61219881/140983587-6f78d168-74de-458d-82bd-f8b56f05aa99.png)



Reference:
- [github docs for templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates)